### PR TITLE
Add an Expect class that saves its position

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The general recipe for how to use this is as follows:
   1. Write your test and use `assertExpectedInline()` instead of a normal
      `assertEqual`.  Leave the expected argument blank with an empty string:
      ```py
-     self.assertExpectedInline(some_func(), "")
+     self.assertExpectedInline(some_func(), """""")
      ```
 
   2. Run your test.  It should fail, and you get an error message about
@@ -26,7 +26,7 @@ The general recipe for how to use this is as follows:
   3. Rerun the test with `EXPECTTEST_ACCEPT=1`.  Now the previously blank string
      literal will contain the expected value of the test.
      ```py
-     self.assertExpectedInline(some_func(), "my_value")
+     self.assertExpectedInline(some_func(), """my_value""")
      ```
 ## A minimal working example
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The general recipe for how to use this is as follows:
      ```py
      self.assertExpectedInline(some_func(), """my_value""")
      ```
+
 ## A minimal working example
 
 ```python
@@ -60,6 +61,22 @@ def test_split():
 Run `EXPECTTEST_ACCEPT=1 pytest test.py` , and the content in triple-quoted string
 will be automatically updated.
 
+For parameterized tests, advanced fixturing and other cases where the
+expectation is in a different place than the assertion, use `Expect`:
+
+```python
+from expecttest import Expect
+
+def test_removing_spaces(s: str, expected: Expect) -> None:
+    expected.assert_expected(s.replace(" ", ""))
+
+test_removing_spaces("foo bar", Expect("""foobar"""))
+test_removing_spaces("foo bar !!", Expect(""""""))
+```
+
+Run `EXPECTTEST_ACCEPT=1 pytest test.py` , and the content in triple-quoted string
+will be automatically updated.
+
 ## Some tips and tricks
 
   - Often, you will want to expect test on a multiline string.  This framework
@@ -69,3 +86,7 @@ will be automatically updated.
   - Take some time thinking about how exactly you want to design the output
     format of the expect test.  It is often profitable to design an output
     representation specifically for expect tests.
+
+## Similar libraries
+
+- [expect-test](https://docs.rs/expect-test) for Rust

--- a/expecttest/__init__.py
+++ b/expecttest/__init__.py
@@ -156,9 +156,9 @@ def replace_string_literal(
 
     new_string = normalize_nl(new_string)
 
-    delta = [new_string.count("\n")]
-    if delta[0] > 0:
-        delta[0] += 1  # handle the extra \\\n
+    delta = new_string.count("\n")
+    if delta > 0:
+        delta += 1  # handle the extra \\\n
 
     assert start_lineno <= end_lineno
     start = nth_line(src, start_lineno)
@@ -166,6 +166,8 @@ def replace_string_literal(
     assert start <= end
 
     def replace(m: Match[str]) -> str:
+        nonlocal delta
+
         s = new_string
         raw = m.group("raw") == "r"
         if not raw or not ok_for_raw_triple_quoted_string(s, quote=m.group("quote")[0]):
@@ -177,7 +179,7 @@ def replace_string_literal(
                 s = escape_trailing_quote(s, '"').replace('"""', r"\"\"\"")
 
         new_body = "\\\n" + s if "\n" in s and not raw else s
-        delta[0] -= m.group("body").count("\n")
+        delta -= m.group("body").count("\n")
         return "".join(
             [
                 "r" if raw else "",
@@ -189,7 +191,7 @@ def replace_string_literal(
 
     return (
         src[:start] + RE_EXPECT.sub(replace, src[start:end], count=1) + src[end:],
-        delta[0],
+        delta,
     )
 
 

--- a/expecttest/__init__.py
+++ b/expecttest/__init__.py
@@ -277,7 +277,7 @@ def assert_expected_inline(
                 # breadth first)
                 for n in ast.walk(old_ast):
                     if isinstance(n, ast.Expr):
-                        if hasattr(n, "end_lineno"):
+                        if hasattr(n, "end_lineno") and n.end_lineno:
                             assert LINENO_AT_START
                             if n.lineno == start_lineno:
                                 end_lineno = n.end_lineno  # type: ignore[attr-defined]

--- a/smoketests/accept_expected.py
+++ b/smoketests/accept_expected.py
@@ -1,0 +1,9 @@
+from expecttest import Expect
+
+exps = [
+    Expect("""ok"""),
+    Expect("""changeme"""),
+]
+
+for exp in exps:
+    exp.assert_expected("ok")

--- a/test_expecttest.py
+++ b/test_expecttest.py
@@ -18,6 +18,7 @@ from hypothesis.strategies import booleans, composite, integers, sampled_from, t
 
 import expecttest
 
+
 def sh(file: str, accept: bool = False) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
     env = ""
     if accept:
@@ -245,6 +246,20 @@ Accepting new output at test.py:5
             finally:
                 os.environ.clear()
                 os.environ.update(env)
+
+    def test_smoketest_expected_objects(self) -> None:
+        with smoketest("accept_expected.py") as test_py:
+            r = sh(test_py)
+            self.assertNotEqual(r.returncode, 0)
+            r = sh(test_py, accept=True)
+            self.assertExpectedInline(
+                r.stdout.replace(test_py, "test.py"),
+                """\
+Accepting new output at test.py:5
+""",
+            )
+            r = sh(test_py)
+            self.assertEqual(r.returncode, 0)
 
 
 def load_tests(

--- a/test_expecttest.py
+++ b/test_expecttest.py
@@ -9,13 +9,14 @@ import traceback
 import unittest
 import tempfile
 import runpy
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Generator
+from contextlib import contextmanager
+from pathlib import Path
 
 import hypothesis
 from hypothesis.strategies import booleans, composite, integers, sampled_from, text
 
 import expecttest
-
 
 def sh(file: str, accept: bool = False) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
     env = ""
@@ -40,6 +41,18 @@ def text_lineno(draw: Any) -> Tuple[str, int]:
     t = draw(text("a\n"))
     lineno = draw(integers(min_value=1, max_value=t.count("\n") + 1))
     return (t, lineno)
+
+
+@contextmanager
+def smoketest(name: str) -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as d:
+        dst = Path(d) / "test.py"
+        code_dir = Path(__file__).parent
+        shutil.copy(
+            code_dir / "smoketests" / name,
+            dst,
+        )
+        yield str(dst)
 
 
 class TestExpectTest(expecttest.TestCase):
@@ -164,62 +177,45 @@ c"""
             self.assertEqual(tb1[0].lineno + 1 + 2, tb2[0].lineno)
 
     def test_smoketest_accept_twice(self) -> None:
-        with tempfile.TemporaryDirectory() as d:
-            dst = os.path.join(d, "test.py")
-            shutil.copy(
-                os.path.join(os.path.dirname(__file__), "smoketests/accept_twice.py"),
-                dst,
-            )
-            r = sh(dst)
+        with smoketest("accept_twice.py") as test_py:
+            r = sh(test_py)
             self.assertNotEqual(r.returncode, 0)
-            r = sh(dst, accept=True)
+            r = sh(test_py, accept=True)
             self.assertExpectedInline(
-                r.stdout.replace(dst, "test.py"),
+                r.stdout.replace(test_py, "test.py"),
                 """\
 Accepting new output for __main__.Test.test_a at test.py:10
 Skipping already accepted output for __main__.Test.test_a at test.py:10
 Accepting new output for __main__.Test.test_b at test.py:21
 """,
             )
-            r = sh(dst)
+            r = sh(test_py)
             self.assertEqual(r.returncode, 0)
 
     def test_smoketest_no_unittest(self) -> None:
-        with tempfile.TemporaryDirectory() as d:
-            dst = os.path.join(d, "test.py")
-            shutil.copy(
-                os.path.join(os.path.dirname(__file__), "smoketests/no_unittest.py"),
-                dst,
-            )
-            r = sh(dst)
+        with smoketest("no_unittest.py") as test_py:
+            r = sh(test_py)
             self.assertNotEqual(r.returncode, 0)
-            r = sh(dst, accept=True)
+            r = sh(test_py, accept=True)
             self.assertExpectedInline(
-                r.stdout.replace(dst, "test.py"),
+                r.stdout.replace(str(test_py), "test.py"),
                 """\
 Accepting new output at test.py:5
 """,
             )
-            r = sh(dst)
+            r = sh(test_py)
             self.assertEqual(r.returncode, 0)
 
     def test_smoketest_accept_twice_reload(self) -> None:
-        with tempfile.TemporaryDirectory() as d:
-            dst = os.path.join(d, "test.py")
-            shutil.copy(
-                os.path.join(
-                    os.path.dirname(__file__), "smoketests/accept_twice_reload.py"
-                ),
-                dst,
-            )
+        with smoketest("accept_twice_reload.py") as test_py:
             env = os.environ.copy()
             try:
                 os.environ["EXPECTTEST_ACCEPT"] = "1"
-                runpy.run_path(dst)
-                expecttest.EDIT_HISTORY.reload_file(dst)
+                runpy.run_path(test_py)
+                expecttest.EDIT_HISTORY.reload_file(test_py)
                 try:
                     expecttest._TEST1 = True  # type: ignore[attr-defined]
-                    runpy.run_path(dst)
+                    runpy.run_path(test_py)
                 finally:
                     delattr(expecttest, "_TEST1")
             finally:
@@ -227,30 +223,23 @@ Accepting new output at test.py:5
                 os.environ.update(env)
 
             # Should pass
-            runpy.run_path(dst)
+            runpy.run_path(test_py)
             try:
                 expecttest._TEST1 = True  # type: ignore[attr-defined]
-                runpy.run_path(dst)
+                runpy.run_path(test_py)
             finally:
                 delattr(expecttest, "_TEST1")
 
     def test_smoketest_accept_twice_clobber(self) -> None:
-        with tempfile.TemporaryDirectory() as d:
-            dst = os.path.join(d, "test.py")
-            shutil.copy(
-                os.path.join(
-                    os.path.dirname(__file__), "smoketests/accept_twice_clobber.py"
-                ),
-                dst,
-            )
+        with smoketest("accept_twice_clobber.py") as test_py:
             env = os.environ.copy()
             try:
                 os.environ["EXPECTTEST_ACCEPT"] = "1"
-                runpy.run_path(dst)
-                expecttest.EDIT_HISTORY.reload_file(dst)
+                runpy.run_path(test_py)
+                expecttest.EDIT_HISTORY.reload_file(test_py)
                 try:
                     expecttest._TEST2 = True  # type: ignore[attr-defined]
-                    self.assertRaises(AssertionError, lambda: runpy.run_path(dst))
+                    self.assertRaises(AssertionError, lambda: runpy.run_path(test_py))
                 finally:
                     delattr(expecttest, "_TEST2")
             finally:


### PR DESCRIPTION
Hi! This implements #25 in a way that is completely neutral to the testing library in use :3

I would recommend reviewing this commit-by-commit, as it was written <del>as-if I was writing it for Gerrit</del> in a way that is split into small, easy to review commits that each pass tests on their own. There's a bunch of refactors in this PR, and although they don't necessarily always purely relate to the task at hand, they gradually build up to making the feature implementation small and nice.

Enjoy :)

I am super excited to be able to use this library for Lix with this feature, and I expect it will become a very well-used tool in our new Python-based integration tests.